### PR TITLE
fixed styling causing map attr to be hidden

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -42,7 +42,7 @@ body {
 
 .sticky-header {
   position: sticky;
-  top: 0;
+  top: -10px;
   padding: 10px;
   margin-left: -10px;
   margin-right: -10px;
@@ -72,4 +72,20 @@ body {
 .app-sidebar {
   box-shadow: 2px 0 5px rgba(20, 33, 42, 0.25);
   z-index: 10;
+  overflow: auto;
+}
+
+.ant-layout {
+  max-height: 100vh;
+}
+
+.ant-layout-content {
+  flex: 1;
+  display: flex;
+}
+
+.ant-layout-content > div {
+  height: auto !important;
+  width: auto !important;
+  flex: 1;
 }

--- a/src/layouts/index.css
+++ b/src/layouts/index.css
@@ -1,5 +1,5 @@
 
 .main {
-  height: 100hv;
-  width: 100wv;
+  height: 100vh;
+  width: 100vw;
 }


### PR DESCRIPTION
There was a CSS layout issue causing the Map's attribution from displaying outside of the visible viewport. This PR fixes this.

![image](https://user-images.githubusercontent.com/1928955/88567184-22792500-d005-11ea-92e1-7fdc1bae67eb.png)

Fixes this issue https://github.com/azavea/demos/issues/73